### PR TITLE
git_commit can be Nothing

### DIFF
--- a/src/connection.jl
+++ b/src/connection.jl
@@ -15,7 +15,7 @@ struct NATSInfo
     server_name::String
     version::String
     proto::Int64
-    git_commit::String
+    git_commit::Union{String, Nothing}
     go::String
     host::String
     port::Int64


### PR DESCRIPTION
Noticed when using `nats_server_jll` to provide the broker.